### PR TITLE
added flac to the supported types

### DIFF
--- a/auramixer.py
+++ b/auramixer.py
@@ -86,7 +86,7 @@ def load_all_assets(asset_paths):
     backgrounds_path = asset_paths["backgrounds"]
     effects_path = asset_paths["effects"]
     music_path = asset_paths["music"]
-    valid_audio_ext = ('.wav', '.mp3', '.ogg')
+    valid_audio_ext = ('.wav', '.mp3', '.ogg', '.flac')
 
     # Load Backgrounds
     background_images = []


### PR DESCRIPTION
Initially, I wanted to support M4A, since it is one of the most commonly used audio file formats. However, it looks like PiGameMixer alone doesn't have the ability to load M4A files. It seems that this needs packaging FFmpeg or something like that. I can work on this if you give me permission and if you think it's something that will benefit the project. However, the implementation of FLAC works great, and I have tested it. 